### PR TITLE
Add explicit procfile to set docroot.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: vendor/bin/heroku-php-nginx public/


### PR DESCRIPTION
This sets the document root for nginx, letting Heroku serve the app from inside `public/`.

Example deployment: https://wcss-heroku.herokuapp.com/

Closes #57.